### PR TITLE
Authenticated downloads

### DIFF
--- a/lib/node_download.js
+++ b/lib/node_download.js
@@ -1,22 +1,32 @@
 var spawn = require('child_process').spawn,
 events = require('events');
 function CurlDownloader() {
-	
+
 	var dirToSave = './';
 	var dl;
 	var dlOptions;
 	var lastProgress = 0;
-		
+  var authVal
+  var authType
+
 	var eventEmitter = new events.EventEmitter();
-	
+
+  this.setAuthType = function (type) {
+    authType = type
+  }
+
+  this.setPrivateToken = function (token) {
+    authVal = '-H' + authType + ':' + token
+  }
+
 	this.setDirToSave = function(dir) {
 		dirToSave = dir;
 	}
-	
+
 	this.getDirToSave = function() {
 		return dirToSave;
 	}
-	
+
 	this.downloadFile = function(url, file) {
 		console.log('Beginning Download from: ' + url + ' Saving to: ' + dirToSave);
 
@@ -26,22 +36,22 @@ function CurlDownloader() {
 
 		// Clean filename
 		file = file.replace(/[^0-9a-zA-Z\.]+/gi, '');
-	
+
 		var path = dirToSave+file;
-		
-		dlOptions = [url, '--create-dirs', '-o' + path, '-#', '--insecure'];
+
+		dlOptions = [authVal, url, '--create-dirs', '-o' + path, '-#', '--insecure'];
 
 		dl = spawn('curl', dlOptions);
-		
+
 		dl.on('exit', function (code) {
 			// Important for multiple downloads to know when they are finished.
 			eventEmitter.emit('end', code);
 		});
-		
+
 		dl.stderr.on('data', function (data) {
-			
+
 			data = data.toString('ascii');
-			
+
 			// Extract the progress percentage
 			if (/\d+(\.\d{1,2})/.test(data)) {
 				var progress = parseInt(RegExp.lastMatch);
@@ -49,23 +59,25 @@ function CurlDownloader() {
 				// Do only when percentage changed
 				if (lastProgress != progress && progress >= lastProgress) {
 					lastProgress = progress;
-					
+
 					eventEmitter.emit('progress', progress + '%');
 				}
 			}
-			
+
 		});
 
 		dl.stdin.end();
 	}
-	
+
 	this.stopDownload = function() {
 		console.log('Download stopped');
 		dl.kill();
 	}
-	
+
 	// Expose the public API
 	return {
+    setPrivateToken: this.setPrivateToken,
+    setAuthType: this.setAuthType,
 		setDirToSave: this.setDirToSave,
 		getDirToSave: this.getDirToSave,
 		downloadFile: this.downloadFile,

--- a/lib/node_download.js
+++ b/lib/node_download.js
@@ -1,23 +1,23 @@
 var spawn = require('child_process').spawn,
-events = require('events');
+	events = require('events');
 function CurlDownloader() {
 
 	var dirToSave = './';
 	var dl;
 	var dlOptions;
 	var lastProgress = 0;
-  var authVal
-  var authType
+	var authVal
+	var authType
 
 	var eventEmitter = new events.EventEmitter();
 
-  this.setAuthType = function (type) {
-    authType = type
-  }
+	this.setAuthType = function(type) {
+		authType = type
+	}
 
-  this.setPrivateToken = function (token) {
-    authVal = '-H' + authType + ':' + token
-  }
+	this.setPrivateToken = function(token) {
+		authVal = '-H' + authType + ':' + token
+	}
 
 	this.setDirToSave = function(dir) {
 		dirToSave = dir;
@@ -31,24 +31,28 @@ function CurlDownloader() {
 		console.log('Beginning Download from: ' + url + ' Saving to: ' + dirToSave);
 
 		if (typeof file == 'undefined') {
-			var file = url.substring(url.lastIndexOf('/')+1);
+			var file = url.substring(url.lastIndexOf('/') + 1);
 		}
 
 		// Clean filename
 		file = file.replace(/[^0-9a-zA-Z\.]+/gi, '');
 
-		var path = dirToSave+file;
+		var path = dirToSave + file;
 
-		dlOptions = [authVal, url, '--create-dirs', '-o' + path, '-#', '--insecure'];
+		dlOptions = [
+			authVal, url, '--create-dirs', '-o' + path,
+			'-#',
+			'--insecure'
+		];
 
 		dl = spawn('curl', dlOptions);
 
-		dl.on('exit', function (code) {
+		dl.on('exit', function(code) {
 			// Important for multiple downloads to know when they are finished.
 			eventEmitter.emit('end', code);
 		});
 
-		dl.stderr.on('data', function (data) {
+		dl.stderr.on('data', function(data) {
 
 			data = data.toString('ascii');
 
@@ -76,8 +80,8 @@ function CurlDownloader() {
 
 	// Expose the public API
 	return {
-    setPrivateToken: this.setPrivateToken,
-    setAuthType: this.setAuthType,
+		setPrivateToken: this.setPrivateToken,
+		setAuthType: this.setAuthType,
 		setDirToSave: this.setDirToSave,
 		getDirToSave: this.getDirToSave,
 		downloadFile: this.downloadFile,


### PR DESCRIPTION
This PR adds 2 methods to support authenticated downloads, in the event you need to pull files from a source that requires credentials.

Example: 
`download.setPrivateToken(<PrivateToken>)`
`download.setAuthType('<AuthenticationMethod>')`

